### PR TITLE
Support submiting HTTP2-Settings header

### DIFF
--- a/griffin.gemspec
+++ b/griffin.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
 
-  spec.add_dependency 'grpc_kit', '>= 0.3.6'
+  spec.add_dependency 'grpc_kit', '>= 0.3.8'
   spec.add_dependency 'serverengine', '~> 2.0.7'
 end

--- a/lib/griffin/engine/server.rb
+++ b/lib/griffin/engine/server.rb
@@ -13,6 +13,7 @@ module Griffin
           min_connection_size: config[:min_connection_size],
           max_connection_size: config[:max_connection_size],
           interceptors: config[:interceptors],
+          settings: config[:http2_settings],
         )
         @socket_manager_path = ServerEngine::SocketManager::Server.generate_path
         @socket_manager_server = ServerEngine::SocketManager::Server.open(@socket_manager_path)

--- a/lib/griffin/server.rb
+++ b/lib/griffin/server.rb
@@ -41,10 +41,11 @@ module Griffin
     # @param min_connection_size [Integer] Maximun connection of TCP
     # @param max_connection_size [Integer] Minimum connection of TCP
     # @param interceptors [Array<GrpcKit::GRPC::ServerInterceptor>] list of interceptors
-    def initialize(min_pool_size:, max_pool_size:, min_connection_size:, max_connection_size:, interceptors: [], **opts)
+    # @param settings [Array<DS9::Settings,Integer> list of HTTP2-Settings headers
+    def initialize(min_pool_size:, max_pool_size:, min_connection_size:, max_connection_size:, interceptors: [], settings: [], **opts)
       @min_connection_size = min_connection_size
       @max_connection_size = max_connection_size
-      @server = GrpcKit::Server.new(interceptors: interceptors, min_pool_size: min_pool_size, max_pool_size: max_pool_size)
+      @server = GrpcKit::Server.new(interceptors: interceptors, min_pool_size: min_pool_size, max_pool_size: max_pool_size, settings: settings)
       @opts = opts
       @status = :run
       @worker_id = 0

--- a/lib/griffin/server.rb
+++ b/lib/griffin/server.rb
@@ -41,7 +41,7 @@ module Griffin
     # @param min_connection_size [Integer] Maximun connection of TCP
     # @param max_connection_size [Integer] Minimum connection of TCP
     # @param interceptors [Array<GrpcKit::GRPC::ServerInterceptor>] list of interceptors
-    # @param settings [Array<DS9::Settings,Integer> list of HTTP2-Settings headers
+    # @param settings [Array<DS9::Settings,Integer>] list of HTTP2-Settings headers
     def initialize(min_pool_size:, max_pool_size:, min_connection_size:, max_connection_size:, interceptors: [], settings: [], **opts)
       @min_connection_size = min_connection_size
       @max_connection_size = max_connection_size

--- a/lib/griffin/server_config_builder.rb
+++ b/lib/griffin/server_config_builder.rb
@@ -16,6 +16,7 @@ module Griffin
       :min_pool_size,
       :max_connection_size,
       :min_connection_size,
+      :http2_settings,
     ].freeze
 
     GRPC_CONFIGS = %i[services interceptors].freeze
@@ -40,6 +41,7 @@ module Griffin
       min_connection_size: DEFAULT_CONNECTION_SIZE,
       interceptors: [],
       services: [],
+      http2_settings: [],
     }.freeze
 
     def initialize
@@ -66,6 +68,10 @@ module Griffin
     def connection_size(min, max)
       @opts[:min_connection_size] = Integer(min)
       @opts[:max_connection_size] = Integer(max)
+    end
+
+    def http2_settings(settings)
+      @opts[:http2_settings] = settings
     end
 
     def interceptors(*value)


### PR DESCRIPTION
Fix to submit HTTP2-Settings header from server.
cf. https://github.com/cookpad/grpc_kit/pull/22

```ruby
Griffin::Server.configure do |c|
  c.http2_settings [[DS9::Settings::MAX_FRAME_SIZE, 655350]]
end
```

@cookpad/infra @ganmacs Please review PR 🙏 