### PR TITLE
Activate travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.4.4
+  - 2.5
+  - 2.6
+  - 2.7
 before_install: gem install bundler -v 1.16.1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Griffin
 
+[![Build Status](https://travis-ci.org/cookpad/griffin.svg?branch=master)](https://travis-ci.org/cookpad/griffin)
 [![Gem Version](https://badge.fury.io/rb/griffin.svg)](https://badge.fury.io/rb/griffin)
 
 Griffin is [gRPC](https://grpc.io/) server which supports multi process by using [serverengine](https://github.com/treasure-data/serverengine).


### PR DESCRIPTION
General housekeeping. Show the build status badge and run on newer versions of Ruby.